### PR TITLE
Add support for processing Citavi annotations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -499,7 +499,15 @@ async function processAnnotations(annotations, pdf, cmapProvider, { keepText = f
 async function importCitaviAnnotations(buf, citaviAnnotations, password, cmapProvider) {
 	const pdf = new PDFAssembler();
 	await pdf.init(buf, password);
-	const annotations = [...citaviAnnotations];
+	const annotations = citaviAnnotations.map(
+		ca => ({
+			...ca,
+			position: {
+				...ca.position,
+				rects: ca.position.rects.map(rect => rect.map(n => Math.round(n * 1000) / 1000))
+			}
+		})
+	);
 	// Citavi annotations come with "text" field correctly pre-populated hence keepText: true
 	await processAnnotations(annotations, pdf, cmapProvider, { keepText: true });
 	return annotations;

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@
 
  ***** END LICENSE BLOCK *****
  */
+/* eslint-env mocha, node */
 
 const path = require('path');
 const expect = require('chai').expect;

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,7 @@
  ***** END LICENSE BLOCK *****
  */
 
+const path = require('path');
 const expect = require('chai').expect;
 
 const fs = require('fs');
@@ -402,5 +403,42 @@ describe('PDF Worker', function () {
 		}];
 
 		expect(annotations).to.deep.equal(result);
+	});
+
+	it('should process Citavi annotations', async () => {
+		const citaviAnnotation = {
+			key: 'B3UENNWP',
+			type: 'highlight',
+			text: null,
+			position:
+			{
+				pageIndex: 0,
+				rects: [
+					[
+						230.20219999999998,
+						578.879472,
+						275.47790585937497,
+						585.816528
+					],
+					[
+						230.20219999999998,
+						578.879472,
+						275.47790585937497,
+						585.816528
+					]
+				]
+			},
+			pageLabel: '',
+			dateAdded: '2022-02-18T17:24:15',
+			dateModified: '2022-02-18T17:24:24',
+			tags: [{ name: 'red' }],
+			color: '#ff6666'
+		};
+		const buf = fs.readFileSync(path.join(__dirname, 'pdfs', '2.pdf'));
+		const [processedAnnotations] = await pdfWorker.importCitaviAnnotations(buf, [citaviAnnotation]);
+		expect(processedAnnotations.key).to.equal('B3UENNWP');
+		expect(processedAnnotations.sortIndex).to.equal('00000|000103|00206');
+		expect(processedAnnotations.text).to.equal('peer-to-peer');
+		expect(processedAnnotations.pageLabel).to.equal('1');
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -441,5 +441,6 @@ describe('PDF Worker', function () {
 		expect(processedAnnotations.sortIndex).to.equal('00000|000103|00206');
 		expect(processedAnnotations.text).to.equal('peer-to-peer');
 		expect(processedAnnotations.pageLabel).to.equal('1');
+		expect(processedAnnotations.position.rects[0]).to.deep.equal([230.202, 578.879, 275.478, 585.817]);
 	});
 });


### PR DESCRIPTION
This PR adapts part of logic that processes Mendeley annotations to also work on (partially prepared) Citavi annotations.

Common code has been extracted into `processAnnotations` with a couple of flags to control the exact behaviour which needs to differ slightly between the two.

This is part of a implementation to add support for importing annotations as part of Citavi import.