### PR TITLE
Add support for inserting blank page at given location

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -365,6 +365,14 @@ async function deletePages(buf, pageIndexes, password) {
 	return pdf.assemblePdf('ArrayBuffer');
 }
 
+async function insertBlankPage(buf, pageIndex, password) {
+	let pdf = new PDFAssembler();
+	await pdf.init(buf, password);
+	let structure = await pdf.getPDFStructure();
+	structure['/Root']['/Pages']['/Kids'].splice(pageIndex, 0, {});
+	return pdf.assemblePdf('ArrayBuffer');
+}
+
 async function rotatePages(buf, pageIndexes, degrees, password) {
 	if (degrees % 90 !== 0 || degrees < 0) {
 		throw new Error('Invalid degrees value');
@@ -973,6 +981,7 @@ module.exports = {
 	writeAnnotations,
 	importAnnotations,
 	deletePages,
+	insertBlankPage,
 	rotatePages,
 	getFulltext,
 	getRecognizerData,


### PR DESCRIPTION
Right now Zotero users can only delete pages from PDFs (right click on thumbnail). This PR will add support for also inserting blank pages (useful for writing notes in PDFs), a feature which was [requested on the forum](https://forums.zotero.org/discussion/103862/any-method-to-add-the-blank-page-to-pdf-file-on-zotero). I've tried the code  on several PDFs (with annotations, references, etc.) and it seems to work fine.